### PR TITLE
Add `topic_id` column to `beatmapsets` table

### DIFF
--- a/migrations/004_BeatmapsetTopic.down.sql
+++ b/migrations/004_BeatmapsetTopic.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE beatmapsets DROP COLUMN topic_id;

--- a/migrations/004_BeatmapsetTopic.up.sql
+++ b/migrations/004_BeatmapsetTopic.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE beatmapsets ADD COLUMN topic_id int REFERENCES forum_topics (id) DEFAULT NULL;


### PR DESCRIPTION
As mentioned in https://github.com/hexis-revival/hexagon/pull/34, we still need a `topic_id` inside of the `beatmapsets` table. This pr will implement that.